### PR TITLE
task-2-sensitive-file keep sensitive props separately

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,9 @@ app:
     max-pool-size: 100
 
 spring:
+  config:
+    import: "sensitive.yaml"
+
   init:
     mode: never
   jpa:
@@ -27,8 +30,6 @@ spring:
         jdbc.batch_size: 20
   datasource:
     url: jdbc:postgresql://localhost:5432/jira
-    username: jira
-    password: JiraRush
 
   liquibase:
     changeLog: "classpath:db/changelog.sql"
@@ -46,35 +47,6 @@ spring:
     cache-names: users
     caffeine.spec: maximumSize=10000,expireAfterAccess=5m
 
-  security:
-    oauth2:
-      client:
-        registration:
-          github:
-            client-id: 3d0d8738e65881fff266
-            client-secret: 0f97031ce6178b7dfb67a6af587f37e222a16120
-            scope:
-              - email
-          google:
-            client-id: 329113642700-f8if6pu68j2repq3ef6umd5jgiliup60.apps.googleusercontent.com
-            client-secret: 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
-            scope:
-              - email
-              - profile
-          gitlab:
-            client-id: b8520a3266089063c0d8261cce36971defa513f5ffd9f9b7a3d16728fc83a494
-            client-secret: e72c65320cf9d6495984a37b0f9cc03ec46be0bb6f071feaebbfe75168117004
-            client-name: GitLab
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-            authorization-grant-type: authorization_code
-            scope: read_user
-        provider:
-          gitlab:
-            authorization-uri: https://gitlab.com/oauth/authorize
-            token-uri: https://gitlab.com/oauth/token
-            user-info-uri: https://gitlab.com/api/v4/user
-            user-name-attribute: email
-
   sql:
     init:
       mode: always
@@ -86,10 +58,7 @@ spring:
           starttls:
             enable: true
           auth: true
-    host: smtp.gmail.com
-    username: jira4jr@gmail.com
-    password: zdfzsrqvgimldzyj
-    port: 587
+
   thymeleaf.check-template-location: false
 
   mvc.throw-exception-if-no-handler-found: true

--- a/src/main/resources/sensitive.yaml
+++ b/src/main/resources/sensitive.yaml
@@ -1,0 +1,39 @@
+spring:
+  datasource:
+    username: jira
+    password: JiraRush
+
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: 3d0d8738e65881fff266
+            client-secret: 0f97031ce6178b7dfb67a6af587f37e222a16120
+            scope:
+              - email
+          google:
+            client-id: 329113642700-f8if6pu68j2repq3ef6umd5jgiliup60.apps.googleusercontent.com
+            client-secret: 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
+            scope:
+              - email
+              - profile
+          gitlab:
+            client-id: b8520a3266089063c0d8261cce36971defa513f5ffd9f9b7a3d16728fc83a494
+            client-secret: e72c65320cf9d6495984a37b0f9cc03ec46be0bb6f071feaebbfe75168117004
+            client-name: GitLab
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope: read_user
+        provider:
+          gitlab:
+            authorization-uri: https://gitlab.com/oauth/authorize
+            token-uri: https://gitlab.com/oauth/token
+            user-info-uri: https://gitlab.com/api/v4/user
+            user-name-attribute: email
+
+  mail:
+    host: smtp.gmail.com
+    username: jira4jr@gmail.com
+    password: zdfzsrqvgimldzyj
+    port: 587


### PR DESCRIPTION
https://javarush.com/quests/lectures/jru.module5.lecture02

Проблема:
Вынести чувствительную информацию в отдельный проперти файл:
- логин
- пароль БД
- идентификаторы для OAuth регистрации/авторизации
- настройки почты
Значения этих проперти должны считываться при старте сервера из переменных окружения машины.

Решение:
вынес в отдельный ямл